### PR TITLE
Added possibility to remove original text watchrer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
     classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'

--- a/phone-field/src/main/java/com/lamudi/phonefield/PhoneField.java
+++ b/phone-field/src/main/java/com/lamudi/phonefield/PhoneField.java
@@ -33,6 +33,8 @@ public abstract class PhoneField extends LinearLayout {
 
   private int mDefaultCountryPosition = 0;
 
+  private TextWatcher originalTextWatcher;
+
   /**
    * Instantiates a new Phone field.
    *
@@ -86,7 +88,7 @@ public abstract class PhoneField extends LinearLayout {
       }
     });
 
-    final TextWatcher textWatcher = new TextWatcher() {
+    originalTextWatcher = new TextWatcher() {
       @Override
       public void beforeTextChanged(CharSequence s, int start, int count, int after) {
 
@@ -120,7 +122,7 @@ public abstract class PhoneField extends LinearLayout {
       }
     };
 
-    mEditText.addTextChangedListener(textWatcher);
+    mEditText.addTextChangedListener(originalTextWatcher);
 
     mSpinner.setAdapter(adapter);
     mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -135,6 +137,13 @@ public abstract class PhoneField extends LinearLayout {
       }
     });
 
+  }
+
+  public void addTextChangedListener(TextWatcher textWatcher, boolean removeOriginal) {
+    mEditText.addTextChangedListener(textWatcher);
+    if (removeOriginal) {
+      mEditText.removeTextChangedListener(originalTextWatcher);
+    }
   }
 
   /**


### PR DESCRIPTION
Sometimes, things need to be done with the text in the text field and the original text watcher might get into the way. We had this on a project and I was forced to fork your project in order to get this functionality. I think this might be useful for other too. It doesn't change any functionality unless you use the new method with the second parameter true. All other cases are just like before