### PR TITLE
update google libphonenumber library to version 8.8.8

### DIFF
--- a/phone-field/build.gradle
+++ b/phone-field/build.gradle
@@ -45,7 +45,7 @@ android {
 dependencies {
   testCompile 'junit:junit:4.12'
   compile 'com.android.support:appcompat-v7:24.1.1'
-  compile 'com.googlecode.libphonenumber:libphonenumber:7.3.1'
+  compile 'com.googlecode.libphonenumber:libphonenumber:8.8.8'
   compile 'com.android.support:design:24.1.1'
 }
 


### PR DESCRIPTION
update google libphonenumber library to version 8.8.8 because of some correct numbers being considered incorrect